### PR TITLE
Locked gsutil to 3.36 to avoid issue with conflicting oauth2 version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     name = "CloudFusion",
     packages = setuptools.find_packages(),
     include_package_data = True,
-    install_requires = ['requests', 'nose', 'simplejson', 'httplib2>=0.8', 'beautifulsoup4', 'argparse', 'ntplib', 'gsutil', 'sh', 'tinydav', 'PyDrive', 'profilehooks', 'psutil'],
+    install_requires = ['requests', 'nose', 'simplejson', 'httplib2>=0.8', 'beautifulsoup4', 'argparse', 'ntplib', 'gsutil==3.36', 'sh', 'tinydav', 'PyDrive', 'profilehooks', 'psutil'],
     version = "7.5.19",
     description = "Filesystem interface to cloud storage services",
     author = "Johannes Mueller",


### PR DESCRIPTION
I haven't extensively tested this other than to make sure it allows python setup.py install to actually work, so beware this may break other things if you are depending on specific features of gsutil (I honestly don't know what you're using gsutil for, nor do I really know what it is)

The issue is described in #39 